### PR TITLE
Prompt for file name

### DIFF
--- a/keycrypt
+++ b/keycrypt
@@ -23,7 +23,7 @@ function defaultKeyLocation() {
 		echo -n "What key file name: "
 		read KEY
 	fi
-
+	
 	if [[ $KEY == *\/* ]] || [[ $KEY == *\\* ]]; then
 		GKEY=$KEY
 	else
@@ -42,19 +42,19 @@ function removeKey() {
 	else
 		echo 'Whoops'
 		exit 1
-	fi
+	fi	
 }
 
 function backupKey() {
 	local KEY=$1
 	local COMMAND="mv $KEY $KEY.bak"
 	local res=""
-
+		
 	if [[ -e $KEY ]]; then
 		if [[ -e "$KEY.bak" ]]; then
 			echo -n "Backup exists, overwrite (y/n): "
 			read res
-
+			
 			case $res in
 				[yY][eE][sS] | [yY] )
 				   	$(rm -rf $KEY.bak)
@@ -77,7 +77,7 @@ function backupKey() {
 		echo "$KEY doesn't exist"
 		exit 0
 	fi
-
+	
 	if [[ -f "$KEY.bak" ]]; then
 		OLD_KEY="$KEY.bak"
 		echo "Backed up key here: $OLD_KEY"
@@ -94,7 +94,7 @@ function fixPermissions() {
 
 function checkEncryptionStatus() {
 	local KEY=$1
-
+	
 	if [[ -n $(grep -i "Proc-Type: 4,ENCRYPTED" $KEY) ]]; then
 		return 1
 	elif [[ -n $(grep -i "BEGIN ENCRYPTED PRIVATE KEY" $KEY) ]]; then
@@ -109,23 +109,23 @@ function encryptKey() {
 	local COMMAND='openssl pkcs8 -topk8 -v2 des3'
 	local PASS=""
 	local CONFIRM_PASS=""
-
+	
 	read -s -p "Password: " PASS
 	echo ""
 	read -s -p "Confirm Password: " CONFIRM_PASS
 	echo""
-
+	
 	if [[ "$PASS" == "$CONFIRM_PASS" ]]; then
 		echo "Passwords Match!"
 		backupKey $KEY
-
+		
 		COMMAND="$COMMAND -in $OLD_KEY -passin pass:$TMP_PASS -out $KEY -passout stdin 1> /dev/null"
 		echo $PASS | $COMMAND
 		fixPermissions $KEY
 	else
 		echo "Password don't match"
 	fi
-
+	
 }
 
 function reencryptKey() {
@@ -134,25 +134,25 @@ function reencryptKey() {
 	local PASS=""
 	local CONFIRM_PASS=""
 	local CURRENT_PASS=""
-
+	
 	res=$(checkEncryptionStatus $KEY)
-
+	
 	if [[ $? == 1 ]]; then
 		read -s -p "Current Password: " CURRENT_PASS
 		echo ""
 	else
 		echo "No encryption on current key."
-	fi
-
+	fi	
+	
 	read -s -p "New Password: " PASS
 	echo ""
 	read -s -p "Confirm Password: " CONFIRM_PASS
 	echo""
-
+	
 	if [[ "$PASS" == "$CONFIRM_PASS" ]]; then
 		echo "Passwords Match!"
 		backupKey $KEY
-
+		
 		COMMAND="$COMMAND -in $OLD_KEY -passin stdin -out $KEY -passout stdin 1> /dev/null"
 		$COMMAND << EOF
 $CURRENT_PASS
@@ -201,16 +201,17 @@ function createKey() {
 		echo 'Invalid bit size.'
 		exit 1
 	fi
-
+	
 	OUTPUT_DIR="-f $KEY"
-
+	
 	COMMAND="$COMMAND $TYPE $BITS $OUTPUT_DIR $PASS"
-
+	
 	$COMMAND 1> /dev/null
 }
 
 function checkKeyExistence() {
 	local KEY=$1
+
 	if [[ -f $KEY ]]; then
 		echo "$KEY exists"
 		echo -n 'Would you like to remove (y/n): '
@@ -239,7 +240,7 @@ function checkCopiedPubKey() {
 	local PUBKEY=$(cat $1)
 	local PARAMS=$2
 	local AUTHORIZED_KEYS
-
+	
 	if [[ -n $(ssh $PARAMS "grep '$PUBKEY' $HOME/.ssh/authorized_keys") ]]; then
 		echo 'Public Key copied!'
 	else
@@ -257,12 +258,12 @@ function copyPubKey() {
 
 	echo -n "Remote Server (user@server:port): "
 	read SERVER
-
+	
 	if [[ $SERVER == *:* ]]; then
-
+		
 		PORT="$(cut -d ":" -f 2 <<< $SERVER)"
 		SERVER="$(cut -d ":" -f 1 <<< $SERVER)"
-
+		
 		PARAMS="$SERVER -p $PORT"
 	else
 		PARAMS="$SERVER"
@@ -277,7 +278,7 @@ function copyPubKey() {
 	else
 		echo "The key supplied doesn't exist."
 	fi
-
+	
 	{ eval "$ID" ; } | ssh $PARAMS "umask 077; test -d .ssh || mkdir .ssh ; cat >> .ssh/authorized_keys; test -x /sbin/restorecon && /sbin/restorecon .ssh .ssh/authorized_keys" || checkCopiedPubKey $PUBKEY $PARAMS
 }
 
@@ -303,13 +304,13 @@ function askCopyPubKey() {
 
 function checkApplicationInstalled() {
 	local APP=$1
-
+	
 	command -v $APP >/dev/null 2>&1 || { echo >&2 "I require $APP but it's not installed.  Aborting."; exit 1; }
 }
 
 function generatePassword() {
 	TMP_PASS=$(openssl rand -base64 48)
-
+	
 }
 
 function usage() {
@@ -345,7 +346,7 @@ case $1 in
 		echo "Hello, $2"
 		;;
 	[tT][eE][sS][tT] ) #test
-
+		
 		;;
 	[cC][rR][eE][aA][tT][eE] | [cC][rR] ) #create
 		defaultKeyLocation $2

--- a/keycrypt
+++ b/keycrypt
@@ -17,7 +17,13 @@ function defaultKeyLocation() {
 	local KEY=$1
 	local default="$HOME/.ssh/"
 
-	
+	if [ "$KEY" = "" ]
+	then
+		# didn't provide a key name
+		echo -n "What key file name: "
+		read KEY
+	fi
+
 	if [[ $KEY == *\/* ]] || [[ $KEY == *\\* ]]; then
 		GKEY=$KEY
 	else
@@ -36,19 +42,19 @@ function removeKey() {
 	else
 		echo 'Whoops'
 		exit 1
-	fi	
+	fi
 }
 
 function backupKey() {
 	local KEY=$1
 	local COMMAND="mv $KEY $KEY.bak"
 	local res=""
-		
+
 	if [[ -e $KEY ]]; then
 		if [[ -e "$KEY.bak" ]]; then
 			echo -n "Backup exists, overwrite (y/n): "
 			read res
-			
+
 			case $res in
 				[yY][eE][sS] | [yY] )
 				   	$(rm -rf $KEY.bak)
@@ -71,7 +77,7 @@ function backupKey() {
 		echo "$KEY doesn't exist"
 		exit 0
 	fi
-	
+
 	if [[ -f "$KEY.bak" ]]; then
 		OLD_KEY="$KEY.bak"
 		echo "Backed up key here: $OLD_KEY"
@@ -88,7 +94,7 @@ function fixPermissions() {
 
 function checkEncryptionStatus() {
 	local KEY=$1
-	
+
 	if [[ -n $(grep -i "Proc-Type: 4,ENCRYPTED" $KEY) ]]; then
 		return 1
 	elif [[ -n $(grep -i "BEGIN ENCRYPTED PRIVATE KEY" $KEY) ]]; then
@@ -103,23 +109,23 @@ function encryptKey() {
 	local COMMAND='openssl pkcs8 -topk8 -v2 des3'
 	local PASS=""
 	local CONFIRM_PASS=""
-	
+
 	read -s -p "Password: " PASS
 	echo ""
 	read -s -p "Confirm Password: " CONFIRM_PASS
 	echo""
-	
+
 	if [[ "$PASS" == "$CONFIRM_PASS" ]]; then
 		echo "Passwords Match!"
 		backupKey $KEY
-		
+
 		COMMAND="$COMMAND -in $OLD_KEY -passin pass:$TMP_PASS -out $KEY -passout stdin 1> /dev/null"
 		echo $PASS | $COMMAND
 		fixPermissions $KEY
 	else
 		echo "Password don't match"
 	fi
-	
+
 }
 
 function reencryptKey() {
@@ -128,25 +134,25 @@ function reencryptKey() {
 	local PASS=""
 	local CONFIRM_PASS=""
 	local CURRENT_PASS=""
-	
+
 	res=$(checkEncryptionStatus $KEY)
-	
+
 	if [[ $? == 1 ]]; then
 		read -s -p "Current Password: " CURRENT_PASS
 		echo ""
 	else
 		echo "No encryption on current key."
-	fi	
-	
+	fi
+
 	read -s -p "New Password: " PASS
 	echo ""
 	read -s -p "Confirm Password: " CONFIRM_PASS
 	echo""
-	
+
 	if [[ "$PASS" == "$CONFIRM_PASS" ]]; then
 		echo "Passwords Match!"
 		backupKey $KEY
-		
+
 		COMMAND="$COMMAND -in $OLD_KEY -passin stdin -out $KEY -passout stdin 1> /dev/null"
 		$COMMAND << EOF
 $CURRENT_PASS
@@ -195,17 +201,16 @@ function createKey() {
 		echo 'Invalid bit size.'
 		exit 1
 	fi
-	
+
 	OUTPUT_DIR="-f $KEY"
-	
+
 	COMMAND="$COMMAND $TYPE $BITS $OUTPUT_DIR $PASS"
-	
+
 	$COMMAND 1> /dev/null
 }
 
 function checkKeyExistence() {
 	local KEY=$1
-
 	if [[ -f $KEY ]]; then
 		echo "$KEY exists"
 		echo -n 'Would you like to remove (y/n): '
@@ -234,7 +239,7 @@ function checkCopiedPubKey() {
 	local PUBKEY=$(cat $1)
 	local PARAMS=$2
 	local AUTHORIZED_KEYS
-	
+
 	if [[ -n $(ssh $PARAMS "grep '$PUBKEY' $HOME/.ssh/authorized_keys") ]]; then
 		echo 'Public Key copied!'
 	else
@@ -252,12 +257,12 @@ function copyPubKey() {
 
 	echo -n "Remote Server (user@server:port): "
 	read SERVER
-	
+
 	if [[ $SERVER == *:* ]]; then
-		
+
 		PORT="$(cut -d ":" -f 2 <<< $SERVER)"
 		SERVER="$(cut -d ":" -f 1 <<< $SERVER)"
-		
+
 		PARAMS="$SERVER -p $PORT"
 	else
 		PARAMS="$SERVER"
@@ -272,7 +277,7 @@ function copyPubKey() {
 	else
 		echo "The key supplied doesn't exist."
 	fi
-	
+
 	{ eval "$ID" ; } | ssh $PARAMS "umask 077; test -d .ssh || mkdir .ssh ; cat >> .ssh/authorized_keys; test -x /sbin/restorecon && /sbin/restorecon .ssh .ssh/authorized_keys" || checkCopiedPubKey $PUBKEY $PARAMS
 }
 
@@ -298,13 +303,13 @@ function askCopyPubKey() {
 
 function checkApplicationInstalled() {
 	local APP=$1
-	
+
 	command -v $APP >/dev/null 2>&1 || { echo >&2 "I require $APP but it's not installed.  Aborting."; exit 1; }
 }
 
 function generatePassword() {
 	TMP_PASS=$(openssl rand -base64 48)
-	
+
 }
 
 function usage() {
@@ -340,7 +345,7 @@ case $1 in
 		echo "Hello, $2"
 		;;
 	[tT][eE][sS][tT] ) #test
-		
+
 		;;
 	[cC][rR][eE][aA][tT][eE] | [cC][rR] ) #create
 		defaultKeyLocation $2


### PR DESCRIPTION
If the create command doesn't have a filename as an argument, the script proceeds without it, and ultimately fails. This quick change notices that and prompts for it. If the user types the name of a file that already exists, it notices and queries them as usual.